### PR TITLE
Add search match highlighting

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/v9.6.2/cspell.schema.json",
   "version": "0.2",
   "language": "en",
   "useGitignore": true,
@@ -10,13 +11,21 @@
     "go.sum"
   ],
   "words": [
+    "autocolor",
     "ghclient",
     "ghjq",
+    "ghtemplate",
     "iostreams",
+    "jsonpretty",
     "octo",
     "octocat",
     "stdlib",
     "stretchr",
-    "tableprinter"
+    "tablerender",
+    "tableprinter",
+    "tablerow",
+    "timeago",
+    "timefmt",
+    "tmpl"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -25,16 +25,28 @@ gh users heath octo
 ```
 
 Use `-R` / `--repo` to target another repository in `[HOST/]OWNER/REPO` format.
+When color is enabled, matching text in login and name fields is highlighted.
 
-### JSON, jq, and template output
+### JSON and jq output
 
-Use `--json` to select fields from `login,name,email,status`, `--jq` to filter JSON output, and `--template` to format it with a Go template.
+Use `--json` to select fields from `login,name,email,status` and `--jq` to
+filter JSON output.
 
 ```bash
 gh users --json login,name,email,status
 gh users --json login,status --jq '.[] | select(.status != null) | .login'
-gh users --template '{{range .}}{{printf "%s\t%s\n" .login .email}}{{end}}'
 ```
+
+### Template
+
+Use `--template` to format output with a Go template. For the built-in
+formatting and template helpers available through GitHub CLI, run:
+
+```bash
+gh help formatting
+```
+
+This command also documents the built-in jq and template formatting helpers.
 
 ### Upgrade
 

--- a/internal/colors/colors.go
+++ b/internal/colors/colors.go
@@ -1,0 +1,156 @@
+package colors
+
+import (
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+const (
+	greenForeground16 = "\x1b[32m"
+	// Use 30;103 for a bright-yellow background instead of the current dim yellow.
+	blackOnYellow16 = "\x1b[30;43m"
+
+	resetDefault = "\x1b[39;49m"
+	resetAll     = "\x1b[0m"
+)
+
+type match struct {
+	start int
+	end   int
+}
+
+type themeColors struct {
+	namePlain     string
+	highlightSpan string
+}
+
+type fieldStyle struct {
+	plainPrefix     string
+	plainSuffix     string
+	highlightPrefix string
+	highlightSuffix string
+}
+
+// Highlight applies theme-aware highlighting for name-like fields.
+func Highlight(colorScheme *iostreams.ColorScheme, input string, patterns ...string) string {
+	colors := colorsFor(colorScheme)
+	return highlight(fieldStyle{
+		plainPrefix:     colors.namePlain,
+		plainSuffix:     "",
+		highlightPrefix: colors.highlightSpan,
+		highlightSuffix: resetDefault,
+	}, colorScheme, input, patterns...)
+}
+
+// HighlightLogin applies theme-aware highlighting for login fields.
+func HighlightLogin(colorScheme *iostreams.ColorScheme, input string, patterns ...string) string {
+	colors := colorsFor(colorScheme)
+	return highlight(fieldStyle{
+		plainPrefix:     loginPlain(colorScheme),
+		plainSuffix:     resetAll,
+		highlightPrefix: colors.highlightSpan,
+		highlightSuffix: resetDefault,
+	}, colorScheme, input, patterns...)
+}
+
+func highlight(style fieldStyle, colorScheme *iostreams.ColorScheme, input string, patterns ...string) string {
+	if input == "" {
+		return input
+	}
+	if colorScheme == nil || !colorScheme.Enabled {
+		return input
+	}
+
+	matches := findMatches(input, patterns)
+	if len(matches) == 0 {
+		return apply(style.plainPrefix, style.plainSuffix, input)
+	}
+
+	var output strings.Builder
+	output.Grow(len(input) + len(matches)*(len(style.highlightPrefix)+len(style.highlightSuffix)))
+	offset := 0
+	for _, current := range matches {
+		output.WriteString(apply(style.plainPrefix, style.plainSuffix, input[offset:current.start]))
+		output.WriteString(style.highlightPrefix)
+		output.WriteString(input[current.start:current.end])
+		output.WriteString(style.highlightSuffix)
+		offset = current.end
+	}
+	output.WriteString(apply(style.plainPrefix, style.plainSuffix, input[offset:]))
+
+	return output.String()
+}
+
+func colorsFor(colorScheme *iostreams.ColorScheme) themeColors {
+	return themeColors{
+		namePlain:     namePlain(colorScheme),
+		highlightSpan: blackOnYellow16,
+	}
+}
+
+func namePlain(_ *iostreams.ColorScheme) string {
+	return ""
+}
+
+func loginPlain(colorScheme *iostreams.ColorScheme) string {
+	return greenForeground16
+}
+
+func findMatches(input string, patterns []string) []match {
+	lowerInput := strings.ToLower(input)
+	var matches []match
+	for _, pattern := range patterns {
+		lowerPattern := strings.ToLower(pattern)
+		if lowerPattern == "" {
+			continue
+		}
+
+		for offset := 0; offset < len(lowerInput); {
+			index := strings.Index(lowerInput[offset:], lowerPattern)
+			if index < 0 {
+				break
+			}
+
+			start := offset + index
+			end := start + len(lowerPattern)
+			matches = append(matches, match{start: start, end: end})
+			_, size := utf8.DecodeRuneInString(input[start:])
+			offset = start + size
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].start == matches[j].start {
+			return matches[i].end < matches[j].end
+		}
+		return matches[i].start < matches[j].start
+	})
+
+	merged := matches[:1]
+	for _, current := range matches[1:] {
+		last := &merged[len(merged)-1]
+		if current.start <= last.end {
+			if current.end > last.end {
+				last.end = current.end
+			}
+			continue
+		}
+		merged = append(merged, current)
+	}
+
+	return merged
+}
+
+func apply(prefix, suffix, input string) string {
+	if input == "" || prefix == "" {
+		return input
+	}
+	return prefix + input + suffix
+}

--- a/internal/colors/colors_test.go
+++ b/internal/colors/colors_test.go
@@ -1,0 +1,97 @@
+package colors
+
+// cspell:ignore aths mcat mheaths mocto moctocat
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHighlight(t *testing.T) {
+	tests := map[string]struct {
+		colorScheme *iostreams.ColorScheme
+		input       string
+		patterns    []string
+		want        string
+	}{
+		"disabled": {
+			input:    "Octocat",
+			patterns: []string{"octo"},
+			want:     "Octocat",
+		},
+		"no patterns": {
+			colorScheme: enabledScheme(iostreams.DarkTheme),
+			input:       "Octocat",
+			want:        "Octocat",
+		},
+		"empty patterns": {
+			colorScheme: enabledScheme(iostreams.DarkTheme),
+			input:       "Octocat",
+			patterns:    []string{"", ""},
+			want:        "Octocat",
+		},
+		"dark theme 16 color highlight": {
+			colorScheme: enabledScheme(iostreams.DarkTheme),
+			input:       "Octocat OCTO",
+			patterns:    []string{"octo"},
+			want:        "\x1b[30;43mOcto\x1b[39;49mcat \x1b[30;43mOCTO\x1b[39;49m",
+		},
+		"light theme 16 color plain and highlight": {
+			colorScheme: enabledScheme(iostreams.LightTheme),
+			input:       "Octocat",
+			patterns:    []string{"octo"},
+			want:        "\x1b[30;43mOcto\x1b[39;49mcat",
+		},
+		"unknown theme uses dark name plain": {
+			colorScheme: enabledScheme(iostreams.NoTheme),
+			input:       "Octocat",
+			patterns:    []string{"octo"},
+			want:        "\x1b[30;43mOcto\x1b[39;49mcat",
+		},
+		"overlapping patterns": {
+			colorScheme: enabledScheme(iostreams.DarkTheme),
+			input:       "heaths",
+			patterns:    []string{"heat", "aths"},
+			want:        "\x1b[30;43mheaths\x1b[39;49m",
+		},
+		"overlapping occurrences": {
+			colorScheme: enabledScheme(iostreams.DarkTheme),
+			input:       "banana",
+			patterns:    []string{"ana"},
+			want:        "b\x1b[30;43manana\x1b[39;49m",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.want, Highlight(tt.colorScheme, tt.input, tt.patterns...))
+		})
+	}
+}
+
+func TestHighlightLogin(t *testing.T) {
+	t.Run("applies green plain color when there are no matches", func(t *testing.T) {
+		colorScheme := enabledScheme(iostreams.DarkTheme)
+		require.Equal(t, "\x1b[32moctocat\x1b[0m", HighlightLogin(colorScheme, "octocat"))
+	})
+
+	t.Run("uses the shared dark-on-yellow highlight spans", func(t *testing.T) {
+		colorScheme := enabledScheme(iostreams.DarkTheme)
+		want := "\x1b[30;43mocto\x1b[39;49m\x1b[32mcat\x1b[0m"
+		require.Equal(t, want, HighlightLogin(colorScheme, "octocat", "octo"))
+	})
+
+	t.Run("does not style text when color is disabled", func(t *testing.T) {
+		colorScheme := &iostreams.ColorScheme{}
+		require.Equal(t, "octocat", HighlightLogin(colorScheme, "octocat", "octo"))
+	})
+}
+
+func enabledScheme(theme string) *iostreams.ColorScheme {
+	return &iostreams.ColorScheme{
+		Enabled: true,
+		Theme:   theme,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cli/go-gh/pkg/jsonpretty"
 	"github.com/cli/go-gh/pkg/tableprinter"
 	ghtemplate "github.com/cli/go-gh/pkg/template"
+	"github.com/heaths/gh-users/internal/colors"
 	ghclient "github.com/heaths/gh-users/internal/github"
 	"github.com/heaths/gh-users/internal/options"
 	"github.com/spf13/cobra"
@@ -101,7 +102,7 @@ func runUsers(opts *rootOptions, partials []string) error {
 		return writeUserOutput(opts, users)
 	}
 
-	return printUsers(opts.io, users)
+	return printUsers(opts.io, users, partials)
 }
 
 func ensureClient(client userService) (userService, error) {
@@ -131,15 +132,15 @@ func processUsers(response *ghclient.QueryEnvelope) ([]ghclient.User, error) {
 	return users, nil
 }
 
-func printUsers(streams *iostreams.IOStreams, users []ghclient.User) error {
-	colors := streams.ColorScheme()
+func printUsers(streams *iostreams.IOStreams, users []ghclient.User, patterns []string) error {
+	colorScheme := streams.ColorScheme()
 	table := tableprinter.New(streams.Out, streams.IsStdoutTTY(), streams.TerminalWidth())
 
 	for _, user := range users {
-		table.AddField(user.Login, tableprinter.WithTruncate(nil), tableprinter.WithColor(colors.Green))
-		table.AddField(user.Name)
-		table.AddField(user.Email, tableprinter.WithColor(colors.Muted))
-		table.AddField(user.Status, tableprinter.WithColor(colors.Yellow))
+		table.AddField(colors.HighlightLogin(colorScheme, user.Login, patterns...), tableprinter.WithTruncate(nil))
+		table.AddField(colors.Highlight(colorScheme, user.Name, patterns...))
+		table.AddField(user.Email, tableprinter.WithColor(colorScheme.Muted))
+		table.AddField(user.Status, tableprinter.WithColor(colorScheme.Yellow))
 		table.EndRow()
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,12 @@
 package main
 
+// cspell:ignore mcat mheath mocto
+
 import (
 	"testing"
 
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/heaths/gh-users/internal/colors"
 	ghclient "github.com/heaths/gh-users/internal/github"
 	"github.com/stretchr/testify/require"
 )
@@ -182,6 +185,34 @@ func TestRunUsers_FormatsJSONOutputWithTemplate(t *testing.T) {
 	}, []string{"heath"})
 	require.NoError(t, err)
 	require.Equal(t, "heaths\theath@example.com\n", stdout.String())
+}
+
+func TestRunUsers_HighlightsPatternsInDefaultOutput(t *testing.T) {
+	streams, _, stdout, _ := iostreams.Test()
+	streams.SetStdoutTTY(true)
+	streams.SetColorEnabled(true)
+	mock := &mockService{
+		response: &ghclient.QueryEnvelope{
+			Data: ghclient.QueryResponse{
+				Repository: map[string]ghclient.UserConnection{
+					"alias_0": {
+						Nodes: []ghclient.User{
+							{Login: "octocat", Name: "The Octo Cat"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := runUsers(&rootOptions{
+		io:     streams,
+		client: mock,
+		repo:   "heaths/gh-users",
+	}, []string{"OCTO"})
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), colors.HighlightLogin(streams.ColorScheme(), "octocat", "OCTO"))
+	require.Contains(t, stdout.String(), colors.Highlight(streams.ColorScheme(), "The Octo Cat", "OCTO"))
 }
 
 func TestRunUsers_PrintsEmptyOutputWhenNoMatches(t *testing.T) {


### PR DESCRIPTION
Introduce an internal colors package for default table highlighting, keep name text on the terminal default foreground, remove the custom template highlight helper, and point template users to gh help formatting.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: d6e13729-62b8-4b65-8224-4f478b637773
