### PR TITLE
Paginate partial username searches

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -14,6 +14,7 @@
     "autocolor",
     "ghclient",
     "ghjq",
+    "ghterminal",
     "ghtemplate",
     "iostreams",
     "jsonpretty",

--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ gh users heath octo
 
 Use `-R` / `--repo` to target another repository in `[HOST/]OWNER/REPO` format.
 When color is enabled, matching text in login and name fields is highlighted.
-When listing all assignable users, paginated fetches show a spinner on standard
-error when standard error is a TTY, unless `GH_SPINNER_DISABLED=1` or
-`GH_SPINNER_DISABLED=true`.
 
 ### JSON and jq output
 
@@ -65,6 +62,14 @@ gh extension upgrade heaths/gh-users
 # Or upgrade all extensions:
 gh extension upgrade --all
 ```
+
+### Environment variables
+
+When fetching many records, `gh users` displays a spinner. Set
+`GH_SPINNER_DISABLED=1` or `GH_SPINNER_DISABLED=true` to disable it.
+
+Run `gh help environment` for more details about this and other environment
+variables such as `GH_REPO` and `NO_COLOR`.
 
 ## License
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -225,25 +225,19 @@ func (c *Client) QueryUsers(owner, repo string, partials []string) (*QueryEnvelo
 		},
 	}
 
-	if len(partials) > 0 {
-		var response graphqlQueryResponse
-		if err := c.gql.Do(query, vars, &response); err != nil {
-			return nil, err
-		}
-		envelope.Data = response.QueryResponse()
-		if envelope.Data.Repository == nil {
-			envelope.Data.Repository = map[string]UserConnection{}
-		}
-		return envelope, nil
+	connectionCount := len(partials)
+	if connectionCount == 0 {
+		connectionCount = 1
 	}
 
-	var endCursor string
+	active := make([]bool, connectionCount)
+	for i := range active {
+		active[i] = true
+	}
+
 	var indicator progressIndicator
 	for {
 		pagedVars := cloneVariables(vars)
-		if endCursor != "" {
-			pagedVars["endCursor"] = endCursor
-		}
 
 		var response graphqlQueryResponse
 		if err := c.gql.Do(query, pagedVars, &response); err != nil {
@@ -253,13 +247,27 @@ func (c *Client) QueryUsers(owner, repo string, partials []string) (*QueryEnvelo
 			return nil, err
 		}
 
-		connection := response.Repository["alias_0"].UserConnection()
-		aggregated := envelope.Data.Repository["alias_0"]
-		aggregated.Nodes = append(aggregated.Nodes, connection.Nodes...)
-		aggregated.PageInfo = connection.PageInfo
-		envelope.Data.Repository["alias_0"] = aggregated
+		hasNextPage := false
+		for i := range connectionCount {
+			if !active[i] {
+				continue
+			}
 
-		if !connection.PageInfo.HasNextPage {
+			alias := fmt.Sprintf("alias_%d", i)
+			connection := response.Repository[alias].UserConnection()
+			aggregated := envelope.Data.Repository[alias]
+			aggregated.Nodes = append(aggregated.Nodes, connection.Nodes...)
+			aggregated.PageInfo = connection.PageInfo
+			envelope.Data.Repository[alias] = aggregated
+
+			active[i] = connection.PageInfo.HasNextPage
+			if active[i] {
+				hasNextPage = true
+				vars[endCursorVariable(partials, i)] = connection.PageInfo.EndCursor
+			}
+		}
+
+		if !hasNextPage {
 			if indicator != nil {
 				indicator.Stop()
 			}
@@ -272,8 +280,6 @@ func (c *Client) QueryUsers(owner, repo string, partials []string) (*QueryEnvelo
 				indicator.Start()
 			}
 		}
-
-		endCursor = connection.PageInfo.EndCursor
 	}
 
 	return envelope, nil
@@ -287,7 +293,7 @@ func BuildQuery(partials []string) string {
 		query.WriteString(", $endCursor: String")
 	}
 	for i := range partials {
-		fmt.Fprintf(&query, ", $user_%d: String!", i)
+		fmt.Fprintf(&query, ", $user_%d: String!, $endCursor_%d: String", i, i)
 	}
 	query.WriteString(") {\n")
 	query.WriteString("  repository(owner: $owner, name: $repo) {\n")
@@ -304,9 +310,13 @@ func BuildQuery(partials []string) string {
 		query.WriteString("    }\n")
 	} else {
 		for i := range partials {
-			fmt.Fprintf(&query, "    alias_%d: assignableUsers(first: 100, query: $user_%d) {\n", i, i)
+			fmt.Fprintf(&query, "    alias_%d: assignableUsers(first: 100, after: $endCursor_%d, query: $user_%d) {\n", i, i, i)
 			query.WriteString("      nodes {\n")
 			query.WriteString("        ...UserFragment\n")
+			query.WriteString("      }\n")
+			query.WriteString("      pageInfo {\n")
+			query.WriteString("        hasNextPage\n")
+			query.WriteString("        endCursor\n")
 			query.WriteString("      }\n")
 			query.WriteString("    }\n")
 		}
@@ -325,6 +335,14 @@ func BuildQuery(partials []string) string {
 	query.WriteString("}\n")
 
 	return query.String()
+}
+
+func endCursorVariable(partials []string, index int) string {
+	if len(partials) == 0 {
+		return "endCursor"
+	}
+
+	return fmt.Sprintf("endCursor_%d", index)
 }
 
 func cloneVariables(vars map[string]interface{}) map[string]interface{} {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,7 +1,10 @@
 package github
 
+// cspell:ignore mheath
+
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,9 +34,10 @@ func (f *fakeGQLClient) Do(query string, vars map[string]interface{}, response i
 func TestBuildQuery_MultiplePartialsUsesAliasesAndFragment(t *testing.T) {
 	query := BuildQuery([]string{"heath", "octo"})
 
-	require.Contains(t, query, "query Users($owner: String!, $repo: String!, $user_0: String!, $user_1: String!)")
-	require.Contains(t, query, "alias_0: assignableUsers(first: 100, query: $user_0)")
-	require.Contains(t, query, "alias_1: assignableUsers(first: 100, query: $user_1)")
+	require.Contains(t, query, "query Users($owner: String!, $repo: String!, $user_0: String!, $endCursor_0: String, $user_1: String!, $endCursor_1: String)")
+	require.Contains(t, query, "alias_0: assignableUsers(first: 100, after: $endCursor_0, query: $user_0)")
+	require.Contains(t, query, "alias_1: assignableUsers(first: 100, after: $endCursor_1, query: $user_1)")
+	require.Equal(t, 2, strings.Count(query, "pageInfo"))
 	require.Contains(t, query, "fragment UserFragment on User")
 	require.NotContains(t, query, "\n  id\n")
 	require.NotContains(t, query, "databaseId")
@@ -120,13 +124,69 @@ func TestQueryUsers_PaginatesUnfilteredResults(t *testing.T) {
 	require.Equal(t, 1, indicator.stopped)
 }
 
-func TestQueryUsers_StopsSpinnerBeforeReturningError(t *testing.T) {
+func TestQueryUsers_PaginatesPartialResultsByAlias(t *testing.T) {
+	calls := 0
+	indicator := &fakeProgressIndicator{}
+	client := NewWithClient(&fakeGQLClient{
+		do: func(query string, vars map[string]interface{}, response interface{}) error {
+			calls++
+			require.Equal(t, "heath", vars["user_0"])
+			require.Equal(t, "octo", vars["user_1"])
+
+			resp := response.(*graphqlQueryResponse)
+			switch calls {
+			case 1:
+				_, hasFirstCursor := vars["endCursor_0"]
+				require.False(t, hasFirstCursor)
+				_, hasSecondCursor := vars["endCursor_1"]
+				require.False(t, hasSecondCursor)
+				resp.Repository = map[string]graphqlUserConnection{
+					"alias_0": {
+						Nodes: []graphqlUser{{Login: "heaths"}},
+						PageInfo: PageInfo{
+							HasNextPage: true,
+							EndCursor:   "heath-cursor-1",
+						},
+					},
+					"alias_1": {
+						Nodes: []graphqlUser{{Login: "octocat"}},
+					},
+				}
+			case 2:
+				require.Equal(t, "heath-cursor-1", vars["endCursor_0"])
+				_, hasSecondCursor := vars["endCursor_1"]
+				require.False(t, hasSecondCursor)
+				resp.Repository = map[string]graphqlUserConnection{
+					"alias_0": {
+						Nodes: []graphqlUser{{Login: "mheath"}},
+					},
+				}
+			default:
+				return errors.New("unexpected page")
+			}
+
+			return nil
+		},
+	})
+	client.newSpinner = func() progressIndicator { return indicator }
+
+	response, err := client.QueryUsers("heaths", "gh-users", []string{"heath", "octo"})
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+	require.Equal(t, []User{{Login: "heaths"}, {Login: "mheath"}}, response.Data.Repository["alias_0"].Nodes)
+	require.Equal(t, []User{{Login: "octocat"}}, response.Data.Repository["alias_1"].Nodes)
+	require.Equal(t, 1, indicator.started)
+	require.Equal(t, 1, indicator.stopped)
+}
+
+func TestQueryUsers_StopsSpinnerBeforeReturningPartialPagingError(t *testing.T) {
 	calls := 0
 	indicator := &fakeProgressIndicator{}
 	client := NewWithClient(&fakeGQLClient{
 		do: func(query string, vars map[string]interface{}, response interface{}) error {
 			calls++
 			if calls == 2 {
+				require.Equal(t, "cursor-1", vars["endCursor_0"])
 				require.Equal(t, 1, indicator.started)
 				require.Equal(t, 0, indicator.stopped)
 				return errors.New("page 2 failed")
@@ -147,7 +207,7 @@ func TestQueryUsers_StopsSpinnerBeforeReturningError(t *testing.T) {
 	})
 	client.newSpinner = func() progressIndicator { return indicator }
 
-	response, err := client.QueryUsers("heaths", "gh-users", nil)
+	response, err := client.QueryUsers("heaths", "gh-users", []string{"alpha"})
 	require.Nil(t, response)
 	require.EqualError(t, err, "page 2 failed")
 	require.Equal(t, 1, indicator.started)


### PR DESCRIPTION
Track cursors independently for each batched partial search and aggregate all pages before rendering results. Document the spinner control and cover filtered pagination behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 47de0b4d-cda3-4617-88fc-de88cf756b44
